### PR TITLE
check that colon doesn't appear in the sheet name

### DIFF
--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -93,7 +93,9 @@ Workbook$methods(addWorksheet = function(sheetName
                                          , orientation = 'portrait'
                                          , hdpi = 300
                                          , vdpi = 300){
-  
+  if (!missing(sheetName)) {
+    if (grepl(pattern=":", x=sheetName)) stop("colon not allowed in sheet names in Excel")
+  }	
   newSheetIndex = length(worksheets) + 1L
   
   if(newSheetIndex > 1){


### PR DESCRIPTION
Excel does not allow colons in sheet names. Writing a workbook with a colon in the sheet name results in a corrupted file.