### PR TITLE
Adds "all" to the list of the possible values for the borders argument

### DIFF
--- a/R/writexlsx.R
+++ b/R/writexlsx.R
@@ -302,7 +302,7 @@ write.xlsx <- function(x, file, asTable = FALSE, ...){
   borders <- NULL
   if("borders" %in% names(params)){
     borders <- tolower(params$borders)
-    if(!all(borders %in% c("surrounding", "rows", "columns")))
+    if(!all(borders %in% c("surrounding", "rows", "columns", "all")))
       stop("Invalid borders argument")
   }
   


### PR DESCRIPTION
I have added "all" to the list of the possible values for the borders argument at the write.xlsx function. However I could not test it.