### PR TITLE
Add Random Extraction Path to fix parallel processing issue

### DIFF
--- a/R/readWorkbook.R
+++ b/R/readWorkbook.R
@@ -138,7 +138,7 @@ read.xlsx.default <- function(xlsxFile,
   }
   
   ## create temp dir and unzip
-  xmlDir <- file.path(tempdir(), "_excelXMLRead")
+  xmlDir <- file.path(tempdir(),paste0(sample(LETTERS,10),collapse=""),"_excelXMLRead")
   xmlFiles <- unzip(xlsxFile, exdir = xmlDir)
   
   on.exit(unlink(xmlDir, recursive = TRUE), add = TRUE)


### PR DESCRIPTION
Parallel processing of multiple files sometimes fails due to same temp path for all files.  Adding another folder layer of random strings would fix the issue.