### PR TITLE
Fixed extraction of sheet names and identification of sheets with comments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: openxlsx
 Type: Package
 Title: Read, Write and Edit XLSX Files
-Version: 4.1.1
-Date: 2018-05-26
+Version: 4.1.1.1003
+Date: 2018-11-19
 Authors@R: c(
     person("Alexander", "Walker",
     email = "Alexander.Walker1989@gmail.com", role = c("aut", "cre")),
@@ -30,7 +30,7 @@ VignetteBuilder: knitr
 Suggests:
     knitr,
     testthat
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.1
 Collate: 
     'CommentClass.R'
     'HyperlinkClass.R'

--- a/R/loadWorkbook.R
+++ b/R/loadWorkbook.R
@@ -772,7 +772,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE){
       hasDrawing <- sapply(drawXMLrelationship, length) > 0 ## which sheets have a drawing
       
       commentXMLrelationship <- lapply(xml, function(x) x[grepl("comments[0-9]+\\.xml", x)])
-      hasComment <- sapply(commentXMLrelationship, length) > 0 ## which sheets have a drawing
+      hasComment <- sapply(commentXMLrelationship, length) > 0 ## which sheets have a comment
       
       for(i in 1:length(xml)){
         

--- a/R/loadWorkbook.R
+++ b/R/loadWorkbook.R
@@ -144,8 +144,14 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE){
     
     workbook <- readLines(workbookXML, warn=FALSE, encoding="UTF-8")
     workbook <-  removeHeadTag(workbook)
+    sheets <- unlist(regmatches(workbook, gregexpr("(?<=<sheets>).*(?=</sheets>)", workbook, perl = TRUE)))
+    sheets <- unlist(regmatches(sheets, gregexpr("<sheet[^>]*>", sheets, perl=TRUE)))
     
-    sheets <- unlist(regmatches(workbook, gregexpr("<sheet .*/sheets>", workbook, perl = TRUE)))
+    ## Some veryHidden sheets do not have a sheet content and their rId is empty.
+    ## Such sheets need to be filtered out because otherwise their sheet names
+    ## occur in the list of all sheet names, leading to a wrong association
+    ## of sheet names with sheet indeces.
+    sheets <- grep('r:id="[[:blank:]]*"', sheets, invert = TRUE, value = TRUE)
     
     ## sheetId is meaningless
     ## sheet rId links to the workbook.xml.resl which links worksheets/sheet(i).xml file
@@ -154,6 +160,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE){
     sheetrId <- unlist(getRId(sheets))
     sheetId <- unlist(regmatches(sheets, gregexpr('(?<=sheetId=")[0-9]+', sheets, perl = TRUE)))
     sheetNames <- unlist(regmatches(sheets, gregexpr('(?<=name=")[^"]+', sheets, perl = TRUE)))
+    sheetNames <- replaceXMLEntities(sheetNames)
     
     is_chart_sheet <- sheetrId %in% chartSheetRIds
     is_visible <- !grepl("hidden",  unlist(strsplit(sheets, split = "<sheet "))[-1])

--- a/R/loadWorkbook.R
+++ b/R/loadWorkbook.R
@@ -765,7 +765,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE){
       hasDrawing <- sapply(drawXMLrelationship, length) > 0 ## which sheets have a drawing
       
       commentXMLrelationship <- lapply(xml, function(x) x[grepl("comments[0-9]+\\.xml", x)])
-      hasComment <- sapply(drawXMLrelationship, length) > 0 ## which sheets have a drawing
+      hasComment <- sapply(commentXMLrelationship, length) > 0 ## which sheets have a drawing
       
       for(i in 1:length(xml)){
         

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -3061,7 +3061,15 @@ getSheetNames <- function(file){
   workbook <- xmlFiles[grepl("workbook.xml$", xmlFiles, perl = TRUE)]
   workbook <- readLines(workbook, warn=FALSE, encoding="UTF-8")
   workbook <-  removeHeadTag(workbook)
-  sheets <- unlist(regmatches(workbook, gregexpr("<sheet .*/sheets>", workbook, perl = TRUE)))
+  sheets <- unlist(regmatches(workbook, gregexpr("(?<=<sheets>).*(?=</sheets>)", workbook, perl = TRUE)))
+  sheets <- unlist(regmatches(sheets, gregexpr("<sheet[^>]*>", sheets, perl=TRUE)))
+
+  ## Some veryHidden sheets do not have a sheet content and their rId is empty.
+  ## Such sheets need to be filtered out because otherwise their sheet names
+  ## occur in the list of all sheet names, leading to a wrong association
+  ## of sheet names with sheet indeces.
+  sheets <- grep('r:id="[[:blank:]]*"', sheets, invert = TRUE, value = TRUE)
+  
   sheetNames <- unlist(regmatches(sheets, gregexpr('(?<=name=")[^"]+', sheets, perl = TRUE)))
   sheetNames <- replaceXMLEntities(sheetNames)
   

--- a/man/addStyle.Rd
+++ b/man/addStyle.Rd
@@ -4,7 +4,8 @@
 \alias{addStyle}
 \title{Add a style to a set of cells}
 \usage{
-addStyle(wb, sheet, style, rows, cols, gridExpand = FALSE, stack = FALSE)
+addStyle(wb, sheet, style, rows, cols, gridExpand = FALSE,
+  stack = FALSE)
 }
 \arguments{
 \item{wb}{A Workbook object containing a worksheet.}

--- a/man/addWorksheet.Rd
+++ b/man/addWorksheet.Rd
@@ -7,11 +7,12 @@
 addWorksheet(wb, sheetName, gridLines = TRUE, tabColour = NULL,
   zoom = 100, header = NULL, footer = NULL, evenHeader = NULL,
   evenFooter = NULL, firstHeader = NULL, firstFooter = NULL,
-  visible = TRUE, paperSize = getOption("openxlsx.paperSize", default = 9),
-  orientation = getOption("openxlsx.orientation", default = "portrait"),
-  vdpi = getOption("openxlsx.vdpi", default = getOption("openxlsx.dpi",
-  default = 300)), hdpi = getOption("openxlsx.hdpi", default =
-  getOption("openxlsx.dpi", default = 300)))
+  visible = TRUE, paperSize = getOption("openxlsx.paperSize", default =
+  9), orientation = getOption("openxlsx.orientation", default =
+  "portrait"), vdpi = getOption("openxlsx.vdpi", default =
+  getOption("openxlsx.dpi", default = 300)),
+  hdpi = getOption("openxlsx.hdpi", default = getOption("openxlsx.dpi",
+  default = 300)))
 }
 \arguments{
 \item{wb}{A Workbook object to attach the new worksheet}

--- a/man/createWorkbook.Rd
+++ b/man/createWorkbook.Rd
@@ -5,8 +5,8 @@
 \title{Create a new Workbook object}
 \usage{
 createWorkbook(creator = ifelse(.Platform$OS.type == "windows",
-  Sys.getenv("USERNAME"), Sys.getenv("USER")), title = NULL, subject = NULL,
-  category = NULL)
+  Sys.getenv("USERNAME"), Sys.getenv("USER")), title = NULL,
+  subject = NULL, category = NULL)
 }
 \arguments{
 \item{creator}{Creator of the workbook (your name). Defaults to login username}

--- a/man/insertPlot.Rd
+++ b/man/insertPlot.Rd
@@ -4,8 +4,9 @@
 \alias{insertPlot}
 \title{Insert the current plot into a worksheet}
 \usage{
-insertPlot(wb, sheet, width = 6, height = 4, xy = NULL, startRow = 1,
-  startCol = 1, fileType = "png", units = "in", dpi = 300)
+insertPlot(wb, sheet, width = 6, height = 4, xy = NULL,
+  startRow = 1, startCol = 1, fileType = "png", units = "in",
+  dpi = 300)
 }
 \arguments{
 \item{wb}{A workbook object}

--- a/man/makeHyperlinkString.Rd
+++ b/man/makeHyperlinkString.Rd
@@ -4,7 +4,8 @@
 \alias{makeHyperlinkString}
 \title{create Excel hyperlink string}
 \usage{
-makeHyperlinkString(sheet, row = 1, col = 1, text = NULL, file = NULL)
+makeHyperlinkString(sheet, row = 1, col = 1, text = NULL,
+  file = NULL)
 }
 \arguments{
 \item{sheet}{Name of a worksheet}

--- a/man/pageSetup.Rd
+++ b/man/pageSetup.Rd
@@ -5,9 +5,9 @@
 \title{Set page margins, orientation and print scaling}
 \usage{
 pageSetup(wb, sheet, orientation = NULL, scale = 100, left = 0.7,
-  right = 0.7, top = 0.75, bottom = 0.75, header = 0.3, footer = 0.3,
-  fitToWidth = FALSE, fitToHeight = FALSE, paperSize = NULL,
-  printTitleRows = NULL, printTitleCols = NULL)
+  right = 0.7, top = 0.75, bottom = 0.75, header = 0.3,
+  footer = 0.3, fitToWidth = FALSE, fitToHeight = FALSE,
+  paperSize = NULL, printTitleRows = NULL, printTitleCols = NULL)
 }
 \arguments{
 \item{wb}{A workbook object}

--- a/man/read.xlsx.Rd
+++ b/man/read.xlsx.Rd
@@ -6,8 +6,9 @@
 \usage{
 read.xlsx(xlsxFile, sheet = 1, startRow = 1, colNames = TRUE,
   rowNames = FALSE, detectDates = FALSE, skipEmptyRows = TRUE,
-  skipEmptyCols = TRUE, rows = NULL, cols = NULL, check.names = FALSE,
-  namedRegion = NULL, na.strings = "NA", fillMergedCells = FALSE)
+  skipEmptyCols = TRUE, rows = NULL, cols = NULL,
+  check.names = FALSE, namedRegion = NULL, na.strings = "NA",
+  fillMergedCells = FALSE)
 }
 \arguments{
 \item{xlsxFile}{An xlsx file, Workbook object or URL to xlsx file.}

--- a/man/readWorkbook.Rd
+++ b/man/readWorkbook.Rd
@@ -6,8 +6,9 @@
 \usage{
 readWorkbook(xlsxFile, sheet = 1, startRow = 1, colNames = TRUE,
   rowNames = FALSE, detectDates = FALSE, skipEmptyRows = TRUE,
-  skipEmptyCols = TRUE, rows = NULL, cols = NULL, check.names = FALSE,
-  namedRegion = NULL, na.strings = "NA", fillMergedCells = FALSE)
+  skipEmptyCols = TRUE, rows = NULL, cols = NULL,
+  check.names = FALSE, namedRegion = NULL, na.strings = "NA",
+  fillMergedCells = FALSE)
 }
 \arguments{
 \item{xlsxFile}{An xlsx file, Workbook object or URL to xlsx file.}


### PR DESCRIPTION
The commits fix two issues:

1. There was a copy&paste bug for the identification of sheets with comments with the effect that sheets with drawings instead of sheets with comments were set to hasComment=TRUE.
2. Some xlsm files I wanted to read returned wrong sheets if sheets were requested by sheet names. It turned out that this is due to veryHidden sheets with an empty r:id. Sheet names for such sheets are now ignored.