### PR TITLE
Write mixed EDT/EST DateTimes

### DIFF
--- a/tests/testthat/test-writing_posixct.R
+++ b/tests/testthat/test-writing_posixct.R
@@ -41,3 +41,41 @@ test_that("Writing Posixct with writeData & writeDataTable", {
   
 })
 
+test_that("Writing mixed EDT/EST Posixct with writeData & writeDataTable", {
+  
+  options("openxlsx.datetimeFormat" = "dd/mm/yy hh:mm")
+  
+  tstart1 <- strptime("12/03/2018 08:30", "%d/%m/%Y %H:%M", tz="America/New_York")
+  tstart2 <- strptime("10/03/2018 08:30", "%d/%m/%Y %H:%M", tz="America/New_York")
+  TimeDT1 <- c(0,10,30,60,120,240,720,1440)*60 + tstart1
+  TimeDT2 <- c(0,10,30,60,120,240,720,1440)*60 + tstart2
+  
+  df <- data.frame(timeval = c(TimeDT1, TimeDT2),
+                   timetxt = format(c(TimeDT1, TimeDT2),"%Y-%m-%d %H:%M"))
+  
+  wb <- createWorkbook()
+  addWorksheet(wb, "writeData")
+  addWorksheet(wb, "writeDataTable")
+  
+  writeData(wb, "writeData", df, startCol = 2, startRow = 3, rowNames = FALSE)
+  writeDataTable(wb, "writeDataTable", df, startCol = 2, startRow = 3)
+  
+  wd <- as.numeric(wb$worksheets[[1]]$sheet_data$v)
+  wdt <- as.numeric(wb$worksheets[[2]]$sheet_data$v)
+  
+  
+  expected <- c(0, 1, 43171.3541666667, 2, 43171.3611111111, 3, 43171.3750000000,
+                4, 43171.3958333333, 5, 43171.4375000000, 6, 43171.5208333333, 7, 
+                43171.8541666667, 8, 43172.3541666667, 9, 43169.3541666667, 10, 
+                43169.3611111111, 11, 43169.3750000000, 12, 43169.3958333333, 13, 
+                43169.4375000000, 14, 43169.5208333333, 15, 43169.8541666667, 16,
+                43170.3958333333, 17)
+  
+  expect_equal(object = round(wd, 12), expected = expected)
+  expect_equal(object = round(wdt, 12), expected = expected)
+  expect_equal(object = wd, expected = wdt)
+  
+  options("openxlsx.datetimeFormat" = "yyyy-mm-dd hh:mm:ss")
+  
+})
+


### PR DESCRIPTION
## Issue

When writing to a worksheet, the timezone of the first non-na value in a datetime column is used to calculate Excel compatible datetimes for all values in the column.

If the first non-na value's timezone is EST/EDT, then other values in the column that are EDT/EST will be offset improperly by -/+ 1 hour.

See the below example.

```r

library(openxlsx)
library(lubridate)

packageVersion("openxlsx")

x <- data.frame(
  a = c(ymd_hms("2018-03-12 11:00:00", tz = "America/New_York"),
        ymd_hms("2018-03-10 11:00:00", tz = "America/New_York")),
  b = c(ymd_hms("2018-03-10 11:00:00", tz = "America/New_York"),
        ymd_hms("2018-03-12 11:00:00", tz = "America/New_York"))
)

write.xlsx(x, file = "test.xlsx")
y   <- read.xlsx("test.xlsx")
y$a <- convertToDateTime(y$a, tz = "America/New_York")
y$b <- convertToDateTime(y$b, tz = "America/New_York")
y
```

```
## [1] '4.1.0'

##                     a                   b
## 1 2018-03-12 11:00:00 EDT 2018-03-10 11:00:00 EST
## 2 2018-03-10 12:00:00 EST 2018-03-12 10:00:00 EDT
```

See also issue #424.

## Fix

This PR adapts the existing code so that all values' timezones in a datetime column are considered rather than only the first non-na value's timezone.

## Benchmark

Using all values for the Excel datetime calculation is more computationally expensive. This simple benchmark indicates that the cost is < 1 second increase per 100K datetime values written.

``` r
library(openxlsx)
library(lubridate)
library(rbenchmark)

n <- 10^5
t <- 1:n*60 + ymd_hms("1970-03-10 11:00:00", tz = "America/New_York")
x <- data.frame(t1 = t, t2 = t, t3 = t, t4 = t, t5 = t)

benchmark(
  "version" = {write.xlsx(x, file = "test.xlsx")},
  replications = 5,
  columns = c("test", "replications", "elapsed",
              "relative", "user.self", "sys.self")
)
```

```
test  replications elapsed relative user.self sys.self
4.0.1            5  12.748        1    11.921    0.742
PR               5  17.767        1    16.697    0.967
```
