### PR TITLE
Feat sep.names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ VignetteBuilder: knitr
 Suggests:
     knitr,
     testthat
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.1
 Collate: 
     'CommentClass.R'
     'HyperlinkClass.R'

--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,9 @@
 openxlsx 4.1.1
 ----------------------------------------------------------------
 
+NEW FEATURES
 
+* sep.names allows choose other separator than '.' for variable names with a blank inside
 
 openxlsx 4.1.0
 ----------------------------------------------------------------

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -81,8 +81,8 @@ getCellInfo <- function(xmlFile, sharedStrings, skipEmptyRows, startRow, rows, g
     .Call(`_openxlsx_getCellInfo`, xmlFile, sharedStrings, skipEmptyRows, startRow, rows, getDates)
 }
 
-read_workbook <- function(cols_in, rows_in, v, string_inds, is_date, hasColNames, skipEmptyRows, skipEmptyCols, nRows, clean_names) {
-    .Call(`_openxlsx_read_workbook`, cols_in, rows_in, v, string_inds, is_date, hasColNames, skipEmptyRows, skipEmptyCols, nRows, clean_names)
+read_workbook <- function(cols_in, rows_in, v, string_inds, is_date, hasColNames, hasSepNames, skipEmptyRows, skipEmptyCols, nRows, clean_names) {
+    .Call(`_openxlsx_read_workbook`, cols_in, rows_in, v, string_inds, is_date, hasColNames, hasSepNames, skipEmptyRows, skipEmptyCols, nRows, clean_names)
 }
 
 calc_number_rows <- function(x, skipEmptyRows) {

--- a/R/helperFunctions.R
+++ b/R/helperFunctions.R
@@ -768,9 +768,9 @@ getSharedStringsFromFile <- function(sharedStringsFile, isFile){
 }
 
 
-clean_names <- function(x){
+clean_names <- function(x,schar){
   x <- gsub("^[[:space:]]+|[[:space:]]+$", "", x)
-  x <- gsub("[[:space:]]+", ".", x)
+  x <- gsub("[[:space:]]+", schar, x)
   return(x)
 }
 

--- a/R/readWorkbook.R
+++ b/R/readWorkbook.R
@@ -19,6 +19,7 @@
 #' If NULL, all rows are read.
 #' @param check.names logical. If TRUE then the names of the variables in the data frame 
 #' are checked to ensure that they are syntactically valid variable names
+#' @param sep.names One character which substitutes blanks in column names. By default, "."
 #' @param namedRegion A named region in the Workbook. If not NULL startRow, rows and cols parameters are ignored.
 #' @param na.strings A character vector of strings which are to be interpreted as NA. Blank cells will be returned as NA.
 #' @param fillMergedCells If TRUE, the value in a merged cell is given to all cells within the merge.
@@ -72,6 +73,7 @@ read.xlsx <- function(xlsxFile,
                       rows = NULL,
                       cols = NULL,
                       check.names = FALSE,
+                      sep.names = ".",
                       namedRegion = NULL,
                       na.strings = "NA",
                       fillMergedCells = FALSE){
@@ -92,6 +94,7 @@ read.xlsx.default <- function(xlsxFile,
                               rows = NULL,
                               cols = NULL,
                               check.names = FALSE,
+                              sep.names = ".",
                               namedRegion = NULL,
                               na.strings = "NA",
                               fillMergedCells = FALSE){
@@ -120,6 +123,9 @@ read.xlsx.default <- function(xlsxFile,
   
   if(!is.logical(check.names))
     stop("check.names must be TRUE/FALSE.")
+  
+  if(!is.character(sep.names) | nchar(sep.names)!=1)
+    stop("sep.names must be a character and only one.")
   
   if(length(sheet) > 1)
     stop("sheet must be of length 1.")
@@ -440,6 +446,7 @@ read.xlsx.default <- function(xlsxFile,
                      string_inds = string_refs,
                      is_date = isDate,
                      hasColNames = colNames,
+                     hasSepNames = sep.names,
                      skipEmptyRows = skipEmptyRows,
                      skipEmptyCols = skipEmptyCols,
                      nRows = nRows,
@@ -494,6 +501,7 @@ readWorkbook <- function(xlsxFile,
                          rows = NULL,
                          cols = NULL,
                          check.names = FALSE,
+                         sep.names = ".",
                          namedRegion = NULL,
                          na.strings = "NA",
                          fillMergedCells = FALSE){
@@ -509,6 +517,7 @@ readWorkbook <- function(xlsxFile,
             rows = rows,
             cols = cols,
             check.names = check.names,
+            sep.names = ".",
             namedRegion = namedRegion,
             na.strings = na.strings,
             fillMergedCells = fillMergedCells)

--- a/R/workbook_read_workbook.R
+++ b/R/workbook_read_workbook.R
@@ -14,6 +14,7 @@ read.xlsx.Workbook <- function(xlsxFile,
                                rows = NULL,
                                cols = NULL,
                                check.names = FALSE,
+                               sep.names = ".",
                                namedRegion = NULL,
                                na.strings = "NA",
                                fillMergedCells = FALSE){
@@ -34,6 +35,9 @@ read.xlsx.Workbook <- function(xlsxFile,
   
   if(!is.logical(check.names))
     stop("check.names must be TRUE/FALSE.")
+  
+  if(!is.character(sep.names) | nchar(sep.names)!=1)
+    stop("sep.names must be a character and only one.")
   
   if(length(sheet) != 1)
     stop("sheet must be of length 1.")
@@ -326,6 +330,7 @@ read.xlsx.Workbook <- function(xlsxFile,
                      , string_inds = string_refs
                      , is_date = isDate
                      , hasColNames = colNames
+                     , hasSepNames = sep.names
                      , skipEmptyRows = skipEmptyRows
                      , skipEmptyCols = skipEmptyCols
                      , nRows = nRows

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -2066,7 +2066,9 @@ pageSetup <- function(wb, sheet, orientation = NULL, scale = 100,
 #' addWorksheet(wb, "S1")
 #' writeDataTable(wb, 1, x = iris[1:30,])
 #' # Formatting cells / columns is allowed , but inserting / deleting columns is protected:
-#' protectWorksheet(wb, "S1", protect = TRUE, lockFormattingCells = FALSE, lockFormattingColumns = FALSE, lockInsertingColumns = TRUE, lockDeletingColumns = TRUE)
+#' protectWorksheet(wb, "S1", protect = TRUE, 
+#'                  lockFormattingCells = FALSE, lockFormattingColumns = FALSE, 
+#'                  lockInsertingColumns = TRUE, lockDeletingColumns = TRUE)
 #' 
 #' # Remove the protection
 #' protectWorksheet(wb, "S1", protect = FALSE)

--- a/man/addStyle.Rd
+++ b/man/addStyle.Rd
@@ -4,7 +4,8 @@
 \alias{addStyle}
 \title{Add a style to a set of cells}
 \usage{
-addStyle(wb, sheet, style, rows, cols, gridExpand = FALSE, stack = FALSE)
+addStyle(wb, sheet, style, rows, cols, gridExpand = FALSE,
+  stack = FALSE)
 }
 \arguments{
 \item{wb}{A Workbook object containing a worksheet.}

--- a/man/addWorksheet.Rd
+++ b/man/addWorksheet.Rd
@@ -7,11 +7,12 @@
 addWorksheet(wb, sheetName, gridLines = TRUE, tabColour = NULL,
   zoom = 100, header = NULL, footer = NULL, evenHeader = NULL,
   evenFooter = NULL, firstHeader = NULL, firstFooter = NULL,
-  visible = TRUE, paperSize = getOption("openxlsx.paperSize", default = 9),
-  orientation = getOption("openxlsx.orientation", default = "portrait"),
-  vdpi = getOption("openxlsx.vdpi", default = getOption("openxlsx.dpi",
-  default = 300)), hdpi = getOption("openxlsx.hdpi", default =
-  getOption("openxlsx.dpi", default = 300)))
+  visible = TRUE, paperSize = getOption("openxlsx.paperSize", default =
+  9), orientation = getOption("openxlsx.orientation", default =
+  "portrait"), vdpi = getOption("openxlsx.vdpi", default =
+  getOption("openxlsx.dpi", default = 300)),
+  hdpi = getOption("openxlsx.hdpi", default = getOption("openxlsx.dpi",
+  default = 300)))
 }
 \arguments{
 \item{wb}{A Workbook object to attach the new worksheet}

--- a/man/createWorkbook.Rd
+++ b/man/createWorkbook.Rd
@@ -5,8 +5,8 @@
 \title{Create a new Workbook object}
 \usage{
 createWorkbook(creator = ifelse(.Platform$OS.type == "windows",
-  Sys.getenv("USERNAME"), Sys.getenv("USER")), title = NULL, subject = NULL,
-  category = NULL)
+  Sys.getenv("USERNAME"), Sys.getenv("USER")), title = NULL,
+  subject = NULL, category = NULL)
 }
 \arguments{
 \item{creator}{Creator of the workbook (your name). Defaults to login username}

--- a/man/insertPlot.Rd
+++ b/man/insertPlot.Rd
@@ -4,8 +4,9 @@
 \alias{insertPlot}
 \title{Insert the current plot into a worksheet}
 \usage{
-insertPlot(wb, sheet, width = 6, height = 4, xy = NULL, startRow = 1,
-  startCol = 1, fileType = "png", units = "in", dpi = 300)
+insertPlot(wb, sheet, width = 6, height = 4, xy = NULL,
+  startRow = 1, startCol = 1, fileType = "png", units = "in",
+  dpi = 300)
 }
 \arguments{
 \item{wb}{A workbook object}

--- a/man/makeHyperlinkString.Rd
+++ b/man/makeHyperlinkString.Rd
@@ -4,7 +4,8 @@
 \alias{makeHyperlinkString}
 \title{create Excel hyperlink string}
 \usage{
-makeHyperlinkString(sheet, row = 1, col = 1, text = NULL, file = NULL)
+makeHyperlinkString(sheet, row = 1, col = 1, text = NULL,
+  file = NULL)
 }
 \arguments{
 \item{sheet}{Name of a worksheet}

--- a/man/pageSetup.Rd
+++ b/man/pageSetup.Rd
@@ -5,9 +5,9 @@
 \title{Set page margins, orientation and print scaling}
 \usage{
 pageSetup(wb, sheet, orientation = NULL, scale = 100, left = 0.7,
-  right = 0.7, top = 0.75, bottom = 0.75, header = 0.3, footer = 0.3,
-  fitToWidth = FALSE, fitToHeight = FALSE, paperSize = NULL,
-  printTitleRows = NULL, printTitleCols = NULL)
+  right = 0.7, top = 0.75, bottom = 0.75, header = 0.3,
+  footer = 0.3, fitToWidth = FALSE, fitToHeight = FALSE,
+  paperSize = NULL, printTitleRows = NULL, printTitleCols = NULL)
 }
 \arguments{
 \item{wb}{A workbook object}

--- a/man/protectWorksheet.Rd
+++ b/man/protectWorksheet.Rd
@@ -60,7 +60,9 @@ wb <- createWorkbook()
 addWorksheet(wb, "S1")
 writeDataTable(wb, 1, x = iris[1:30,])
 # Formatting cells / columns is allowed , but inserting / deleting columns is protected:
-protectWorksheet(wb, "S1", protect = TRUE, lockFormattingCells = FALSE, lockFormattingColumns = FALSE, lockInsertingColumns = TRUE, lockDeletingColumns = TRUE)
+protectWorksheet(wb, "S1", protect = TRUE, 
+                 lockFormattingCells = FALSE, lockFormattingColumns = FALSE, 
+                 lockInsertingColumns = TRUE, lockDeletingColumns = TRUE)
 
 # Remove the protection
 protectWorksheet(wb, "S1", protect = FALSE)

--- a/man/read.xlsx.Rd
+++ b/man/read.xlsx.Rd
@@ -6,8 +6,9 @@
 \usage{
 read.xlsx(xlsxFile, sheet = 1, startRow = 1, colNames = TRUE,
   rowNames = FALSE, detectDates = FALSE, skipEmptyRows = TRUE,
-  skipEmptyCols = TRUE, rows = NULL, cols = NULL, check.names = FALSE,
-  namedRegion = NULL, na.strings = "NA", fillMergedCells = FALSE)
+  skipEmptyCols = TRUE, rows = NULL, cols = NULL,
+  check.names = FALSE, sep.names = ".", namedRegion = NULL,
+  na.strings = "NA", fillMergedCells = FALSE)
 }
 \arguments{
 \item{xlsxFile}{An xlsx file, Workbook object or URL to xlsx file.}
@@ -36,6 +37,8 @@ If NULL, all columns are read.}
 
 \item{check.names}{logical. If TRUE then the names of the variables in the data frame 
 are checked to ensure that they are syntactically valid variable names}
+
+\item{sep.names}{One character which substitutes blanks in column names. By default, "."}
 
 \item{namedRegion}{A named region in the Workbook. If not NULL startRow, rows and cols parameters are ignored.}
 

--- a/man/readWorkbook.Rd
+++ b/man/readWorkbook.Rd
@@ -6,8 +6,9 @@
 \usage{
 readWorkbook(xlsxFile, sheet = 1, startRow = 1, colNames = TRUE,
   rowNames = FALSE, detectDates = FALSE, skipEmptyRows = TRUE,
-  skipEmptyCols = TRUE, rows = NULL, cols = NULL, check.names = FALSE,
-  namedRegion = NULL, na.strings = "NA", fillMergedCells = FALSE)
+  skipEmptyCols = TRUE, rows = NULL, cols = NULL,
+  check.names = FALSE, sep.names = ".", namedRegion = NULL,
+  na.strings = "NA", fillMergedCells = FALSE)
 }
 \arguments{
 \item{xlsxFile}{An xlsx file, Workbook object or URL to xlsx file.}
@@ -36,6 +37,8 @@ If NULL, all columns are read.}
 
 \item{check.names}{logical. If TRUE then the names of the variables in the data frame 
 are checked to ensure that they are syntactically valid variable names}
+
+\item{sep.names}{One character which substitutes blanks in column names. By default, "."}
 
 \item{namedRegion}{A named region in the Workbook. If not NULL startRow, rows and cols parameters are ignored.}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -252,8 +252,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // read_workbook
-SEXP read_workbook(IntegerVector cols_in, IntegerVector rows_in, CharacterVector v, IntegerVector string_inds, LogicalVector is_date, bool hasColNames, bool skipEmptyRows, bool skipEmptyCols, int nRows, Function clean_names);
-RcppExport SEXP _openxlsx_read_workbook(SEXP cols_inSEXP, SEXP rows_inSEXP, SEXP vSEXP, SEXP string_indsSEXP, SEXP is_dateSEXP, SEXP hasColNamesSEXP, SEXP skipEmptyRowsSEXP, SEXP skipEmptyColsSEXP, SEXP nRowsSEXP, SEXP clean_namesSEXP) {
+SEXP read_workbook(IntegerVector cols_in, IntegerVector rows_in, CharacterVector v, IntegerVector string_inds, LogicalVector is_date, bool hasColNames, char hasSepNames, bool skipEmptyRows, bool skipEmptyCols, int nRows, Function clean_names);
+RcppExport SEXP _openxlsx_read_workbook(SEXP cols_inSEXP, SEXP rows_inSEXP, SEXP vSEXP, SEXP string_indsSEXP, SEXP is_dateSEXP, SEXP hasColNamesSEXP, SEXP hasSepNamesSEXP, SEXP skipEmptyRowsSEXP, SEXP skipEmptyColsSEXP, SEXP nRowsSEXP, SEXP clean_namesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -263,11 +263,12 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< IntegerVector >::type string_inds(string_indsSEXP);
     Rcpp::traits::input_parameter< LogicalVector >::type is_date(is_dateSEXP);
     Rcpp::traits::input_parameter< bool >::type hasColNames(hasColNamesSEXP);
+    Rcpp::traits::input_parameter< char >::type hasSepNames(hasSepNamesSEXP);
     Rcpp::traits::input_parameter< bool >::type skipEmptyRows(skipEmptyRowsSEXP);
     Rcpp::traits::input_parameter< bool >::type skipEmptyCols(skipEmptyColsSEXP);
     Rcpp::traits::input_parameter< int >::type nRows(nRowsSEXP);
     Rcpp::traits::input_parameter< Function >::type clean_names(clean_namesSEXP);
-    rcpp_result_gen = Rcpp::wrap(read_workbook(cols_in, rows_in, v, string_inds, is_date, hasColNames, skipEmptyRows, skipEmptyCols, nRows, clean_names));
+    rcpp_result_gen = Rcpp::wrap(read_workbook(cols_in, rows_in, v, string_inds, is_date, hasColNames, hasSepNames, skipEmptyRows, skipEmptyCols, nRows, clean_names));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -465,7 +466,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx_int_2_cell_ref", (DL_FUNC) &_openxlsx_int_2_cell_ref, 1},
     {"_openxlsx_get_shared_strings", (DL_FUNC) &_openxlsx_get_shared_strings, 2},
     {"_openxlsx_getCellInfo", (DL_FUNC) &_openxlsx_getCellInfo, 6},
-    {"_openxlsx_read_workbook", (DL_FUNC) &_openxlsx_read_workbook, 10},
+    {"_openxlsx_read_workbook", (DL_FUNC) &_openxlsx_read_workbook, 11},
     {"_openxlsx_calc_number_rows", (DL_FUNC) &_openxlsx_calc_number_rows, 2},
     {"_openxlsx_map_cell_types_to_integer", (DL_FUNC) &_openxlsx_map_cell_types_to_integer, 1},
     {"_openxlsx_map_cell_types_to_char", (DL_FUNC) &_openxlsx_map_cell_types_to_char, 1},

--- a/src/openxlsx_init.c
+++ b/src/openxlsx_init.c
@@ -40,7 +40,7 @@ extern SEXP _openxlsx_map_cell_types_to_char(SEXP);
 extern SEXP _openxlsx_map_cell_types_to_integer(SEXP);
 extern SEXP _openxlsx_matrixRowInds(SEXP);
 extern SEXP _openxlsx_read_file_newline(SEXP);
-extern SEXP _openxlsx_read_workbook(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP _openxlsx_read_workbook(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _openxlsx_write_worksheet_xml(SEXP, SEXP, SEXP, SEXP);
 extern SEXP _openxlsx_write_worksheet_xml_2(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _openxlsx_write_file(SEXP, SEXP, SEXP, SEXP);
@@ -76,7 +76,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_openxlsx_map_cell_types_to_integer",   (DL_FUNC) &_openxlsx_map_cell_types_to_integer,    1},
   {"_openxlsx_matrixRowInds",               (DL_FUNC) &_openxlsx_matrixRowInds,                1},
   {"_openxlsx_read_file_newline",           (DL_FUNC) &_openxlsx_read_file_newline,            1},
-  {"_openxlsx_read_workbook",               (DL_FUNC) &_openxlsx_read_workbook,               10},
+  {"_openxlsx_read_workbook",               (DL_FUNC) &_openxlsx_read_workbook,               11},
   {"_openxlsx_write_worksheet_xml",         (DL_FUNC) &_openxlsx_write_worksheet_xml,          4},
   {"_openxlsx_write_worksheet_xml_2",       (DL_FUNC) &_openxlsx_write_worksheet_xml_2,        5},
   {"_openxlsx_write_file",                   (DL_FUNC) &_openxlsx_write_file,                  4},

--- a/src/read_workbook.cpp
+++ b/src/read_workbook.cpp
@@ -423,6 +423,7 @@ SEXP read_workbook(IntegerVector cols_in,
                    IntegerVector string_inds,
                    LogicalVector is_date,
                    bool hasColNames,
+                   char hasSepNames,
                    bool skipEmptyRows,
                    bool skipEmptyCols,
                    int nRows,
@@ -520,7 +521,7 @@ SEXP read_workbook(IntegerVector cols_in,
     }
     
     // tidy up column names
-    col_names = clean_names(col_names);
+    col_names = clean_names(col_names,hasSepNames);
     
     //--------------------------------------------------------------------------------
     // Remove elements from rows, cols, v that have been used as headers


### PR DESCRIPTION
Feature for `read.xlsx`: sep.names allows choose other separator than '.' for variable names with a blank inside